### PR TITLE
strip out tildes from query before matching

### DIFF
--- a/solr5.x/src/main/java/org/apache/solr/handler/component/QueryAutoFilteringComponent.java
+++ b/solr5.x/src/main/java/org/apache/solr/handler/component/QueryAutoFilteringComponent.java
@@ -321,10 +321,12 @@ public class QueryAutoFilteringComponent extends QueryComponent
             Log.debug("Complex query - do not process");
             return;
         }
+        //strip out any tildes from query string
+        String normalizedStr = qStr.replaceAll("~", "");
 
         // tokenize the query string, if any part of it matches, remove the token from the list and
         // add a filter query with <categoryField>:value:
-        ArrayList<char[]> queryTokens = tokenize(qStr);
+        ArrayList<char[]> queryTokens = tokenize(normalizedStr);
 
         if (queryTokens.size() >= mintok) {
             ModifiableSolrParams modParams = new ModifiableSolrParams(params);


### PR DESCRIPTION
Small modification to allow component to be used with queries using tilde suffix on words for fuzzy matching.